### PR TITLE
Bump to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mr-mime"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = ["John Nunley <jtnunley01@gmail.com>"]
 description = "A no_std MIME type library for Rust"
 repository = "https://github.com/notgull/mr-mime"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ use core::write;
 use memchr::{memchr, memchr2};
 
 macro_rules! matches {
-    ($expr: expr, $($pat:pat)|+) => {{
+    ($expr: expr, $($pat:pat_param)|+) => {{
         match ($expr) {
             $($pat)|+ => true,
             _ => false,


### PR DESCRIPTION
Thanks for the library! Very helpful!

Very minor change:

- Bumping Rust Edition to 2021,
- Fixing a macro issue created by the new edition.

Feel free to ignore if you feel the change is not warranted.